### PR TITLE
State is transferred to the new component instead of using reflection

### DIFF
--- a/samples/Calculator/Pages/MainPage.cs
+++ b/samples/Calculator/Pages/MainPage.cs
@@ -41,7 +41,7 @@ class MainPage : Component<MainPageState>
     {
         return new ContentPage
         {
-            new Grid("Auto * Auto", "*")
+            new Grid("48 * 420", "*")
             {
                 new ThemeToggle(),
                 
@@ -259,7 +259,6 @@ public class ThemeToggle : Component
 public class KeyPad : Component
 {
     private Action<string>? _keyPressedAction;
-    private MauiControls.Grid? _grid;
 
     public KeyPad OnKeyPressed(Action<string> keyPressed)
     {
@@ -269,7 +268,7 @@ public class KeyPad : Component
 
     public override VisualNode Render()
     {
-        return new Grid(refToGrid => _grid = refToGrid)
+        return new Grid()
         {
             RenderButtonMediumEmphasis("C", 0, 0),
             RenderImageButtonMediumEmphasis(Theme.IsDarkTheme ? "plus_minus_white.png" : "plus_minus.png", "+-", 0, 1),
@@ -301,9 +300,9 @@ public class KeyPad : Component
         .Columns("* * * *")
         .ColumnSpacing(16)
         .RowSpacing(16)
-        .Margin(20, 0, 20, 66)
+        .Margin(20, 0, 20, 20)
         .OnSizeChanged(Invalidate)
-        .HeightRequest(Math.Max(72, (_grid?.Width * 1.265671).GetValueOrDefault()));
+        .HeightRequest(400);
     }
 
     Button RenderButtonLowEmphasis(string text, int row, int column)

--- a/src/MauiReactor.HotReloadConsole/Options.cs
+++ b/src/MauiReactor.HotReloadConsole/Options.cs
@@ -5,16 +5,16 @@ namespace MauiReactor.HotReloadConsole
 {
     public class Options
     {
-        [Option('f', "framework", Required = true, HelpText = "Specify the framework: net7.0-android, net7.0-ios or net7.0-maccatalyst")]
+        [Option('f', "framework", Required = true, HelpText = "Specify the framework: net7.0-android, net7.0-ios, net7.0-maccatalyst, or net7.0-windows10.0.XXXXX.0")]
         public string? Framework { get; set; }
 
-        [Option('p', "proj")]
+        [Option('p', "proj", HelpText = "Project file name (if different from that contained in the current directory)")]
         public string? ProjectFileName { get; set; }
 
-        [Option('d', "dir")]
+        [Option('d', "dir", HelpText = "Working directory (if different from the current one)")]
         public string? WorkingDirectory { get; set; }
 
-        [Option('m', "mode")]
+        [Option('m', "mode", HelpText = "Slim(default) or Full")]
         public CompilationMode CompilationMode { get; set; }
 
     }

--- a/src/MauiReactor/Internals/CopyObjectExtensions.cs
+++ b/src/MauiReactor/Internals/CopyObjectExtensions.cs
@@ -2,7 +2,7 @@
 {
     internal static class CopyObjectExtensions
     {
-        public static void CopyProperties(this object source, object dest)
+        public static void CopyProperties(object source, object dest)
         {
             var sourceProps = source
                 .GetType()

--- a/src/MauiReactor/NavigableElement.partial.cs
+++ b/src/MauiReactor/NavigableElement.partial.cs
@@ -17,9 +17,9 @@ namespace MauiReactor
             var thisAsINavigableElement = (INavigableElement)this;
             if (!NativeControl.StyleClass.NullableSequenceEqual(thisAsINavigableElement.Class))
             {
-#if DEBUG
-                System.Diagnostics.Debug.WriteLine($"[{this}] Update 'StyleClass' to {(thisAsINavigableElement.Class == null ? "null" : string.Join(",", thisAsINavigableElement.Class))}");
-#endif
+//#if DEBUG
+//                System.Diagnostics.Debug.WriteLine($"[{this}] Update 'StyleClass' to {(thisAsINavigableElement.Class == null ? "null" : string.Join(",", thisAsINavigableElement.Class))}");
+//#endif
                 NativeControl.StyleClass = thisAsINavigableElement.Class;
             }
 


### PR DESCRIPTION
During migration, when the new component is of the same time (often) as the old one, its state is transferred over to the new one. This will avoid the use of reflection and class instantiation.