### PR TITLE
Added DEBUG preprocessor symbol.

### DIFF
--- a/src/MauiReactor.HotReloadConsole/HotReloadClientEmit.cs
+++ b/src/MauiReactor.HotReloadConsole/HotReloadClientEmit.cs
@@ -16,6 +16,10 @@ namespace MauiReactor.HotReloadConsole
         private Compilation? _projectCompilation;
         private record ParsedFileInfo(string FilePath, SyntaxTree SyntaxTree, DateTime LastModified);
         private readonly Dictionary<string, ParsedFileInfo> _parsedFiles = new();
+        private readonly CSharpParseOptions _parseOptions = CSharpParseOptions.Default.WithPreprocessorSymbols(new List<string>
+        {
+            "DEBUG"
+        });
 
         static HotReloadClientEmit()
         {
@@ -120,7 +124,7 @@ namespace MauiReactor.HotReloadConsole
                 if (parsedFileInfo.LastModified != currentFileLastWriteTime)
                 {
                     var newSyntaxTree = SyntaxFactory.ParseSyntaxTree(
-                        await ReadAllTextFileAsync(notification.FilePath, cancellationToken), cancellationToken: cancellationToken);
+                        await ReadAllTextFileAsync(notification.FilePath, cancellationToken), options: _parseOptions, cancellationToken: cancellationToken);
 
                     Console.WriteLine($"Replacing syntax tree for: {Path.GetRelativePath(_workingDirectory, notification.FilePath)}");
 


### PR DESCRIPTION
Fixes #87 

- Passed DEBUG as a preprocessor symbol.
- **Not sure** how this would affect `.EnableMauiReactorHotReload()` which is also under `if DEBUG`.
- Do we need the same in `HotReloadClientFull`?
