### PR TITLE
State action callbacks

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       Solution_Name: ./src/MauiReactor.Build.sln
       TemplatePack_Name: ./src/MauiReactor.TemplatePack/MauiReactor.TemplatePack.csproj
-      Version: 2.0.4-beta
+      Version: 2.0.5-beta
 
     steps:
     - name: Checkout

--- a/src/MauiReactor/Component.cs
+++ b/src/MauiReactor/Component.cs
@@ -98,11 +98,6 @@ namespace MauiReactor
 
         internal override void MergeWith(VisualNode newNode)
         {
-            //if (newNode is Component newComponentMigrated)
-            //{
-            //    _newComponent = newComponentMigrated;
-            //}
-
             if (newNode.GetType().FullName == GetType().FullName && _isMounted)
             {
                 ((Component)newNode)._isMounted = true;
@@ -201,33 +196,6 @@ namespace MauiReactor
         {
             var parameterContext = new ParameterContext(this);
             return parameterContext.Get<T>(name) ?? throw new InvalidOperationException($"Unable to find parameter with name '{name ?? typeof(T).FullName}'");
-            //IParameter<T>? parameter = null;
-            //Component currentComponent = this;
-
-            //while (true)
-            //{
-            //    while (currentComponent._newComponent != null)
-            //    {
-            //        currentComponent = currentComponent._newComponent;
-            //    }
-
-            //    var parentComponent = currentComponent.GetParent<Component>();
-            //    if (parentComponent == null)
-            //        break;
-
-            //    parameter = parentComponent._parameterContext?.Get<T>(name);
-
-            //    if (parameter != null)
-            //    {
-            //        _parameterContext ??= new ParameterContext(this);
-            //        parameter = _parameterContext.Register((parameter as IParameterWithReferences<T>) ?? throw new InvalidOperationException($"Parameter '{name}' is not of type {typeof(T).FullName}"));
-            //        break;
-            //    }
-
-            //    currentComponent = parentComponent;
-            //}
-
-            //return parameter ?? throw new InvalidOperationException($"Unable to find parameter with name '{name ?? typeof(T).FullName}'");
         }
     
         public static VisualNode Render(Func<ComponentContext, VisualNode> renderFunc)
@@ -236,7 +204,7 @@ namespace MauiReactor
         }
     }
 
-    internal interface IComponentWithState
+    public interface IComponentWithState
     {
         object State { get; internal set; }
 
@@ -254,16 +222,10 @@ namespace MauiReactor
         object Props { get; internal set; }
     }
 
-    public abstract class ComponentWithProps<P> : Component, IComponentWithProps where P : class, new()
+    public abstract class ComponentWithProps<P>(P? props = null) : Component, IComponentWithProps where P : class, new()
     {
-        private readonly bool _derivedProps;
-        private P? _props;
-
-        public ComponentWithProps(P? props = null)
-        {
-            _props = props;
-            _derivedProps = props != null;
-        }
+        private readonly bool _derivedProps = props != null;
+        private P? _props = props;
 
         public P Props
         {
@@ -381,10 +343,7 @@ namespace MauiReactor
 
         void IComponentWithState.RegisterOnStateChanged(Action action)
         {
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            ArgumentNullException.ThrowIfNull(action);
 
             _actionsRegisteredOnStateChange.Add(action);
         }

--- a/src/MauiReactor/VisualNode.cs
+++ b/src/MauiReactor/VisualNode.cs
@@ -421,13 +421,12 @@ namespace MauiReactor
             {
                 var newValue = propertyValue.GetValue();
 
-                dependencyObject.SetPropertyValue(property, newValue);
+                dependencyObject.SetPropertyValue(property, newValue);                
 
-                var containerComponent = ((IVisualNode)this).GetContainerComponent();
-
-                if (containerComponent != null && propertyValue.HasValueFunction)
+                if (propertyValue.HasValueFunction)
                 {
-                    containerComponent.RegisterOnStateChanged(propertyValue.GetValueAction(dependencyObject, property));
+                    var containerComponent = ((IVisualNode)this).GetContainerComponent();
+                    containerComponent?.RegisterOnStateChanged(this, propertyValue.GetValueAction(dependencyObject, property));
                 }
             }
             else


### PR DESCRIPTION
This PR adds the ability to register state callback functions inside item templates.

For example:

```csharp
public override VisualNode Render()
{
    return new ContentPage
    {
        new CollectionView()
            .ItemsSource(State.Persons, RenderItem)
    };
}

private VisualNode RenderItem(IndexedPersonWithAddress item)
{
    return new Border()
    .ScaleX(() =>...use state)
    ;
}
```
