### PR TITLE
Fix scaffold ForceItemsLoad() and OnUpdate() for TemplateHost compatibility

### DIFF
--- a/samples/MauiReactor.TestApp/Controls/ScaffoldedTestItemsControl.cs
+++ b/samples/MauiReactor.TestApp/Controls/ScaffoldedTestItemsControl.cs
@@ -1,0 +1,8 @@
+using MauiReactor;
+
+namespace MauiReactor.TestApp.Controls;
+
+#pragma warning disable CA1010 // Generic interface should also be implemented
+[Scaffold("MauiReactor.TestApp.Controls.Native.TestItemsControl", implementItemTemplate: true)]
+public partial class ScaffoldedTestItemsControl;
+#pragma warning restore CA1010 // Generic interface should also be implemented

--- a/samples/MauiReactor.TestApp/Controls/TestItemsControl.cs
+++ b/samples/MauiReactor.TestApp/Controls/TestItemsControl.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections;
+using Microsoft.Maui.Controls;
+
+namespace MauiReactor.TestApp.Controls.Native;
+
+/// <summary>
+/// Minimal custom control with ItemsSource and ItemTemplate properties,
+/// used to test scaffold generation with <c>implementItemTemplate: true</c>.
+/// </summary>
+public class TestItemsControl : Microsoft.Maui.Controls.View
+{
+    /// <summary>
+    /// When true, setting <see cref="ItemTemplate"/> throws to simulate controls
+    /// that require MAUI handlers for template processing (e.g., PanCardView.CardsView).
+    /// This reproduces the crash path where <c>OnUpdate</c> fails before
+    /// <c>base.OnUpdate()</c> can apply queued properties like AutomationId.
+    /// </summary>
+    public static bool SimulateHandlerDependency { get; set; }
+
+    public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(
+        nameof(ItemsSource),
+        typeof(IEnumerable),
+        typeof(TestItemsControl)
+    );
+
+    public static readonly BindableProperty ItemTemplateProperty = BindableProperty.Create(
+        nameof(ItemTemplate),
+        typeof(DataTemplate),
+        typeof(TestItemsControl),
+        propertyChanged: OnItemTemplateChanged
+    );
+
+    public IEnumerable? ItemsSource
+    {
+        get => (IEnumerable?)GetValue(ItemsSourceProperty);
+        set => SetValue(ItemsSourceProperty, value);
+    }
+
+    public DataTemplate? ItemTemplate
+    {
+        get => (DataTemplate?)GetValue(ItemTemplateProperty);
+        set => SetValue(ItemTemplateProperty, value);
+    }
+
+    private static void OnItemTemplateChanged(
+        BindableObject bindable,
+        object? oldValue,
+        object? newValue
+    )
+    {
+        if (SimulateHandlerDependency && newValue != null)
+        {
+            throw new InvalidOperationException(
+                "TestItemsControl: simulated handler-dependent failure. "
+                    + "Real controls like CardsView fail here because they require "
+                    + "MAUI handlers for internal template processing."
+            );
+        }
+    }
+}

--- a/samples/MauiReactor.TestApp/Pages/ScaffoldItemTemplatePage.cs
+++ b/samples/MauiReactor.TestApp/Pages/ScaffoldItemTemplatePage.cs
@@ -1,0 +1,32 @@
+using MauiReactor.TestApp.Controls;
+
+namespace MauiReactor.TestApp.Pages;
+
+public sealed class ScaffoldItemTemplatePage : Component
+{
+    public override VisualNode Render() =>
+        ContentPage(
+            "Scaffold ItemTemplate Test",
+            VStack(
+                Label("Above the scaffold control").AutomationId("TopLabel"),
+                new ScaffoldedTestItemsControl()
+                    .AutomationId("TestItems")
+                    .ItemsSource(
+                        ["Item1", "Item2", "Item3"],
+                        item => Label(item).AutomationId($"ItemLabel_{item}")
+                    )
+            )
+        );
+}
+
+public sealed class ScaffoldItemTemplateEmptyPage : Component
+{
+    public override VisualNode Render() =>
+        ContentPage(
+            "Scaffold ItemTemplate Empty Test",
+            VStack(
+                new ScaffoldedTestItemsControl().AutomationId("EmptyTestItems"),
+                Label("Below the scaffold control").AutomationId("BottomLabel")
+            )
+        );
+}

--- a/samples/UnitTests/TestScaffoldTemplateHost.cs
+++ b/samples/UnitTests/TestScaffoldTemplateHost.cs
@@ -1,0 +1,74 @@
+using MauiReactor;
+using MauiReactor.TestApp.Controls.Native;
+using MauiReactor.TestApp.Pages;
+using Shouldly;
+
+namespace UnitTests;
+
+/// <summary>
+/// Tests for scaffold-generated controls with <c>implementItemTemplate: true</c>
+/// running in the headless test host (<see cref="TemplateHost"/>).
+/// <para/>
+/// These tests demonstrate two bugs in the scaffold source generator:
+/// <list type="number">
+///   <item>
+///     <c>ForceItemsLoad()</c> returns early without initializing
+///     <c>_loadedForciblyChildren</c> when <c>NativeControl.ItemsSource</c> or
+///     <c>NativeControl.ItemTemplate</c> is null, causing
+///     <c>Validate.EnsureNotNull</c> to throw in <c>Descendants&lt;T&gt;()</c>.
+///   </item>
+///   <item>
+///     <c>OnUpdate()</c> can crash during template setup (setting ItemsSource /
+///     ItemTemplate on the native control), preventing <c>base.OnUpdate()</c>
+///     from running. This leaves <c>AutomationId</c> and other properties from
+///     <c>_propertiesToSet</c> unapplied.
+///   </item>
+/// </list>
+/// </summary>
+public sealed class TestScaffoldTemplateHost
+{
+    [TearDown]
+    public void TearDown()
+    {
+        TestItemsControl.SimulateHandlerDependency = false;
+    }
+
+    [Test]
+    public void ScaffoldWithItemTemplate_RenderSucceeds()
+    {
+        var host = TemplateHost.Create(new ScaffoldItemTemplatePage());
+        host.ShouldNotBeNull();
+    }
+
+    [Test]
+    public void ScaffoldWithItemTemplate_RenderSucceeds_WhenEmpty()
+    {
+        var host = TemplateHost.Create(new ScaffoldItemTemplateEmptyPage());
+        host.ShouldNotBeNull();
+    }
+
+    /// <summary>
+    /// Bug 2: When the native control throws during template setup in <c>OnUpdate()</c>,
+    /// <c>base.OnUpdate()</c> never runs, so <c>AutomationId</c> from
+    /// <c>_propertiesToSet</c> is never applied to the native control.
+    /// <para/>
+    /// This test enables <see cref="TestItemsControl.SimulateHandlerDependency"/> to
+    /// make the control throw when <c>ItemTemplate</c> is set (simulating the behavior
+    /// of handler-dependent controls like PanCardView.CardsView in headless mode).
+    /// The fix wraps the template setup in a try-catch so <c>base.OnUpdate()</c>
+    /// always runs.
+    /// </summary>
+    [Test]
+    public void ScaffoldWithItemTemplate_AutomationIdApplied_WhenOnUpdateThrows()
+    {
+        TestItemsControl.SimulateHandlerDependency = true;
+
+        var host = TemplateHost.Create(new ScaffoldItemTemplatePage());
+
+        // With the bug, base.OnUpdate() never runs when the template setup throws,
+        // so AutomationId is never applied. Find<T>() throws "not found".
+        var control = host.Find<TestItemsControl>("TestItems");
+        control.ShouldNotBeNull();
+        control.AutomationId.ShouldBe("TestItems");
+    }
+}

--- a/src/MauiReactor.ScaffoldGenerator/ScaffoldTypeGenerator.cs
+++ b/src/MauiReactor.ScaffoldGenerator/ScaffoldTypeGenerator.cs
@@ -582,12 +582,13 @@ namespace ");
                     "scendants<TChild>())\r\n                    {\r\n                        yield retur" +
                     "n childChildT;\r\n                    }\r\n                }\r\n            }\r\n       " +
                     " }\r\n\r\n        private void ForceItemsLoad()\r\n        {\r\n            Validate.Ens" +
-                    "ureNotNull(NativeControl);\r\n\r\n            var nativeControlItemsSource = NativeC" +
+                    "ureNotNull(NativeControl);\r\n\r\n            _loadedForciblyChildren = new();\r\n\r\n  " +
+                    "          var nativeControlItemsSource = NativeC" +
                     "ontrol.ItemsSource as IEnumerable;\r\n\r\n            if (nativeControlItemsSource =" +
                     "= null)\r\n            {\r\n                return;\r\n            }\r\n\r\n            if" +
                     " (NativeControl.ItemTemplate == null)\r\n            {\r\n                return;\r\n " +
                     "           }\r\n\r\n            var itemsSource = nativeControlItemsSource.Cast<obje" +
-                    "ct>().ToArray();\r\n\r\n            _loadedForciblyChildren = new();\r\n\r\n            " +
+                    "ct>().ToArray();\r\n\r\n            " +
                     "foreach (var item in itemsSource)\r\n            {\r\n                var itemConten" +
                     "t = (Microsoft.Maui.Controls.BindableObject)NativeControl.ItemTemplate.CreateCon" +
                     "tent();\r\n\r\n                itemContent.BindingContext = item;\r\n            }\r\n  " +
@@ -932,7 +933,8 @@ namespace ");
             
             #line default
             #line hidden
-            this.Write("            \r\n            _loadedForciblyChildren = null;\r\n\r\n            if (this" +
+            this.Write("            \r\n            _loadedForciblyChildren = null;\r\n\r\n            try\r\n  " +
+                    "          {\r\n                if (this" +
                     "As");
             
             #line 248 "C:\Source\github\reactorui-maui\src\MauiReactor.ScaffoldGenerator\ScaffoldTypeGenerator.tt"
@@ -1022,10 +1024,20 @@ namespace ");
             
             #line default
             #line hidden
-            this.Write("            }\r\n            ");
-            
+            this.Write("            }\r\n            }\r\n            catch (Exception ex)\r\n            {\r\n" +
+                    "                // Some controls (e.g. PanCardView.CardsView) perform internal p" +
+                    "rocessing\r\n                // when ItemsSource or ItemTemplate is set that requi" +
+                    "res MAUI platform handlers.\r\n                // In the headless test host (Templ" +
+                    "ateHost), handlers are not available, so this\r\n                // processing can" +
+                    " throw. Catching here ensures base.OnUpdate() still runs so that\r\n             " +
+                    "   // queued properties like AutomationId are applied to the native control.\r\n  " +
+                    "              System.Diagnostics.Debug.WriteLine($\"Scaffold template setup fai" +
+                    "led for ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(FullTypeName));
+            this.Write(": {ex.Message}\");\r\n            }\r\n            ");
+
             #line 273 "C:\Source\github\reactorui-maui\src\MauiReactor.ScaffoldGenerator\ScaffoldTypeGenerator.tt"
- } 
+ }
             
             #line default
             #line hidden

--- a/src/MauiReactor.ScaffoldGenerator/ScaffoldTypeGenerator.tt
+++ b/src/MauiReactor.ScaffoldGenerator/ScaffoldTypeGenerator.tt
@@ -153,6 +153,8 @@ namespace <#= Namespace #>
         {
             Validate.EnsureNotNull(NativeControl);
 
+            _loadedForciblyChildren = new();
+
             var nativeControlItemsSource = NativeControl.ItemsSource as IEnumerable;
 
             if (nativeControlItemsSource == null)
@@ -166,8 +168,6 @@ namespace <#= Namespace #>
             }
 
             var itemsSource = nativeControlItemsSource.Cast<object>().ToArray();
-
-            _loadedForciblyChildren = new();
 
             foreach (var item in itemsSource)
             {
@@ -242,33 +242,45 @@ namespace <#= Namespace #>
             <#}#>
             
             <# if (SupportItemTemplate) { #>
-            
+
             _loadedForciblyChildren = null;
 
-            if (thisAs<#= InterfaceName #>.ItemsSource != null &&
-                NativeControl.ItemsSource == thisAs<#= InterfaceName #>.ItemsSource)
+            try
             {
-                Validate.EnsureNotNull(_customDataTemplate);
+                if (thisAs<#= InterfaceName #>.ItemsSource != null &&
+                    NativeControl.ItemsSource == thisAs<#= InterfaceName #>.ItemsSource)
+                {
+                    Validate.EnsureNotNull(_customDataTemplate);
 
-                _customDataTemplate.Owner = this;
+                    _customDataTemplate.Owner = this;
 
-                _customDataTemplate.Update();
+                    _customDataTemplate.Update();
+                }
+                else if (thisAs<#= InterfaceName #>.ItemsSource != null)
+                {
+                    _customDataTemplate = new CustomDataTemplate(this);
+                    NativeControl.ItemsSource = (<#= ItemsSourceFullyQualifiedName #>)thisAs<#= InterfaceName #>.ItemsSource;
+                    NativeControl.ItemTemplate = _customDataTemplate.DataTemplate;
+                }
+                else
+                {
+                    <# if (IsGenericType) { #>
+                    NativeControl.ClearValue(global::<#= FullTypeName #><TChild>.ItemsSourceProperty);
+                    NativeControl.ClearValue(global::<#= FullTypeName #><TChild>.ItemTemplateProperty);
+                    <# } else { #>
+                    NativeControl.ClearValue(global::<#= FullTypeName #>.ItemsSourceProperty);
+                    NativeControl.ClearValue(global::<#= FullTypeName #>.ItemTemplateProperty);
+                    <# } #>
+                }
             }
-            else if (thisAs<#= InterfaceName #>.ItemsSource != null)
+            catch (Exception ex)
             {
-                _customDataTemplate = new CustomDataTemplate(this);
-                NativeControl.ItemsSource = (<#= ItemsSourceFullyQualifiedName #>)thisAs<#= InterfaceName #>.ItemsSource;
-                NativeControl.ItemTemplate = _customDataTemplate.DataTemplate;
-            }
-            else
-            {
-                <# if (IsGenericType) { #>
-                NativeControl.ClearValue(global::<#= FullTypeName #><TChild>.ItemsSourceProperty);
-                NativeControl.ClearValue(global::<#= FullTypeName #><TChild>.ItemTemplateProperty);
-                <# } else { #>
-                NativeControl.ClearValue(global::<#= FullTypeName #>.ItemsSourceProperty);
-                NativeControl.ClearValue(global::<#= FullTypeName #>.ItemTemplateProperty);
-                <# } #>
+                // Some controls (e.g. PanCardView.CardsView) perform internal processing
+                // when ItemsSource or ItemTemplate is set that requires MAUI platform handlers.
+                // In the headless test host (TemplateHost), handlers are not available, so this
+                // processing can throw. Catching here ensures base.OnUpdate() still runs so that
+                // queued properties like AutomationId are applied to the native control.
+                System.Diagnostics.Debug.WriteLine($"Scaffold template setup failed for <#= FullTypeName #>: {ex.Message}");
             }
             <# } #>
 


### PR DESCRIPTION
## Summary

Fixes #370 — two bugs in the scaffold source generator (`implementItemTemplate: true`) that prevent scaffold controls from working in the headless test host (`TemplateHost`):

- **`ForceItemsLoad()`** returns early without initializing `_loadedForciblyChildren` when `ItemsSource` or `ItemTemplate` is null, causing `Validate.EnsureNotNull` to throw in `Descendants<T>()`. Fix: initialize before the null guards.
- **`OnUpdate()`** can crash during template setup on controls that require MAUI handlers (e.g. `PanCardView.CardsView`), preventing `base.OnUpdate()` from running and leaving `AutomationId` unapplied. Fix: wrap template setup in try-catch so `base.OnUpdate()` always runs.

## Changes

- `ScaffoldTypeGenerator.tt` / `.cs` — both fixes applied to the T4 template and its generated output
- `TestItemsControl.cs` — minimal custom MAUI control with a `SimulateHandlerDependency` flag to reproduce the headless crash
- `ScaffoldedTestItemsControl.cs` — scaffold wrapper for the test control
- `ScaffoldItemTemplatePage.cs` — test components using the scaffold
- `TestScaffoldTemplateHost.cs` — 3 tests (smoke test, empty render, and the bug reproduction)

## Test plan

- [x] New test `ScaffoldWithItemTemplate_AutomationIdApplied_WhenOnUpdateThrows` fails before fix, passes after
- [x] All 23 existing + new tests pass
- [x] `dotnet build` succeeds with no errors